### PR TITLE
fix(chat): save-failure banner with retry — closes #15

### DIFF
--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
-import { Clock, BookmarkPlus } from "lucide-react";
+import { Clock, BookmarkPlus, WifiOff, RotateCcw, X } from "lucide-react";
 import ChatNavbar from "@/components/chat/ChatNavbar";
 import MessageList from "@/components/chat/MessageList";
 import MessageInput from "@/components/chat/MessageInput";
@@ -36,6 +36,7 @@ export default function ChatSession() {
   const {
     messages, setMessages, generating, setGenerating,
     msgRef, push, send, stop, editMessage, regenerate, sendAsAgent,
+    saveError, retrySave, dismissSaveError,
   } = useChat(id);
 
   // DB에서 채팅 히스토리 로드 (페이지 마운트 시 1회)
@@ -357,6 +358,22 @@ export default function ChatSession() {
         )}
       </div>
 
+      {saveError && (
+        <div className="flex items-center gap-2.5 px-4 py-2.5 bg-danger/8 border-t border-danger/15 text-xs text-danger">
+          <WifiOff size={13} className="shrink-0" />
+          <span className="flex-1">대화를 저장하지 못했습니다. 네트워크를 확인하세요.</span>
+          <button
+            onClick={retrySave}
+            className="flex items-center gap-1 px-2 py-1 rounded-lg bg-danger/10 hover:bg-danger/20 transition-colors font-medium"
+          >
+            <RotateCcw size={11} />
+            재시도
+          </button>
+          <button onClick={dismissSaveError} className="p-0.5 hover:opacity-60 transition-opacity">
+            <X size={12} />
+          </button>
+        </div>
+      )}
       <MessageInput
         onSend={handleSend}
         onStop={stop}

--- a/frontend/src/lib/hooks/useChat.ts
+++ b/frontend/src/lib/hooks/useChat.ts
@@ -117,17 +117,18 @@ export function inferProvider(model: string): "openai" | "anthropic" | "google" 
  * 스트리밍 완료 후 user+assistant 쌍을 Celery write-back 배치 엔드포인트로 저장.
  * - 즉시 202 반환 → WS messages_saved 이벤트로 완료 확인
  * - 실패해도 localStorage에는 존재하므로 non-fatal
+ * - 호출자가 .catch()로 실패를 처리할 수 있도록 Promise를 반환
  */
-export async function saveToDb(chatId: string, userMsg: Message, asstMsg: Message) {
+export async function saveToDb(chatId: string, userMsg: Message, asstMsg: Message): Promise<void> {
   if (!isAuthenticated()) return;
   const messages = [
     { id: userMsg.id, role: userMsg.role, content: userMsg.content, images: userMsg.images ?? null },
     { id: asstMsg.id, role: asstMsg.role, content: asstMsg.content, images: null },
   ];
-  apiFetch(`/api/v1/chats/${chatId}/messages/batch`, {
+  await apiFetch(`/api/v1/chats/${chatId}/messages/batch`, {
     method: "POST",
     body: JSON.stringify({ messages }),
-  }).catch((e) => { console.error("saveToDb failed:", e); });
+  });
 }
 
 // ── Hook ─────────────────────────────────────────────────────────────────────
@@ -137,6 +138,8 @@ export function useChat(chatId?: string) {
     chatId ? loadMessages(chatId) : []
   );
   const [generating, setGenerating] = useState(false);
+  const [saveError, setSaveError]   = useState(false);
+  const lastSavePairRef = useRef<{ userMsg: Message; asstMsg: Message } | null>(null);
   const msgRef          = useRef<Message[]>([]);
   const abortRef        = useRef<AbortController | null>(null);
   const lastSendOptsRef = useRef<SendOpts | undefined>(undefined);
@@ -311,7 +314,8 @@ export function useChat(chatId?: string) {
           setGenerating(false);
           abortRef.current = null;
           if (chatId && _userMsg && _asstMsg) {
-            saveToDb(chatId, _userMsg, _asstMsg);
+            lastSavePairRef.current = { userMsg: _userMsg, asstMsg: _asstMsg };
+            saveToDb(chatId, _userMsg, _asstMsg).catch(() => setSaveError(true));
           }
         },
 
@@ -411,5 +415,14 @@ export function useChat(chatId?: string) {
     }
   }, [chatId, push, msgRef]);
 
-  return { messages, setMessages, generating, setGenerating, msgRef, push, addMessage, send, stop, editMessage, regenerate, clear, sendAsAgent };
+  const retrySave = useCallback(() => {
+    if (!chatId || !lastSavePairRef.current) return;
+    const { userMsg, asstMsg } = lastSavePairRef.current;
+    setSaveError(false);
+    saveToDb(chatId, userMsg, asstMsg).catch(() => setSaveError(true));
+  }, [chatId]);
+
+  const dismissSaveError = useCallback(() => setSaveError(false), []);
+
+  return { messages, setMessages, generating, setGenerating, msgRef, push, addMessage, send, stop, editMessage, regenerate, clear, sendAsAgent, saveError, retrySave, dismissSaveError };
 }


### PR DESCRIPTION
## 요약

`saveToDb` 실패 시 사용자에게 아무런 피드백이 없던 문제를 수정합니다.

- `saveToDb` → fire-and-forget에서 `Promise<void>` 반환으로 변경
- `useChat` 훅에 `saveError` / `retrySave` / `dismissSaveError` 노출
- 저장 실패 시 채팅 입력창 위에 얇은 danger 배너 표시
- 재시도 성공 시 배너 자동 제거, X 버튼으로 수동 닫기 가능

## 변경 파일

- `frontend/src/lib/hooks/useChat.ts` — saveToDb Promise 반환, saveError 상태 추가
- `frontend/src/app/chat/[id]/page.tsx` — 저장 실패 배너 UI

## 테스트 계획

- [ ] 네트워크 오프라인 후 메시지 전송 → 배너 표시 확인
- [ ] 재시도 버튼 클릭 → 온라인 복구 시 배너 사라짐 확인
- [ ] X 버튼으로 배너 수동 닫기
- [ ] 정상 저장 시 배너 미표시 확인

Closes #15