### PR TITLE
fix(api-routes): token verification cache + per-user rate limiting

### DIFF
--- a/frontend/src/app/api/chat/route.ts
+++ b/frontend/src/app/api/chat/route.ts
@@ -14,6 +14,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/api/verifyAuth";
+import { checkRateLimit } from "@/lib/api/rateLimit";
+import { RL_CHAT_LIMIT, RL_WINDOW_MS } from "@/lib/constants";
 
 const OLLAMA_URL     = process.env.OLLAMA_URL      ?? "http://localhost:11434";
 const OPENAI_BASE    = process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1";
@@ -62,6 +64,9 @@ export async function POST(req: NextRequest) {
   const authHeader = req.headers.get("authorization") ?? "";
   if (!await verifyToken(authHeader)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!checkRateLimit("chat", authHeader, RL_CHAT_LIMIT, RL_WINDOW_MS)) {
+    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
   }
 
   const body = await req.json() as RequestBody;

--- a/frontend/src/app/api/image/edit/route.ts
+++ b/frontend/src/app/api/image/edit/route.ts
@@ -14,11 +14,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/api/verifyAuth";
 import { resolveSettingsKey } from "@/lib/api/settingsKeyResolver";
+import { checkRateLimit } from "@/lib/api/rateLimit";
+import { RL_IMAGE_EDIT_LIMIT, RL_WINDOW_MS } from "@/lib/constants";
 
 export async function POST(req: NextRequest) {
   const authHeader = req.headers.get("authorization") ?? "";
   if (!await verifyToken(authHeader)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!checkRateLimit("image-edit", authHeader, RL_IMAGE_EDIT_LIMIT, RL_WINDOW_MS)) {
+    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
   }
 
   const apiKey = await resolveSettingsKey(

--- a/frontend/src/app/api/image/route.ts
+++ b/frontend/src/app/api/image/route.ts
@@ -13,6 +13,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/api/verifyAuth";
 import { resolveSettingsKey } from "@/lib/api/settingsKeyResolver";
+import { checkRateLimit } from "@/lib/api/rateLimit";
+import { RL_IMAGE_LIMIT, RL_WINDOW_MS } from "@/lib/constants";
 
 export async function GET(req: NextRequest) {
   const authHeader = req.headers.get("authorization") ?? "";
@@ -44,6 +46,9 @@ export async function POST(req: NextRequest) {
   const authHeader = req.headers.get("authorization") ?? "";
   if (!await verifyToken(authHeader)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!checkRateLimit("image", authHeader, RL_IMAGE_LIMIT, RL_WINDOW_MS)) {
+    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
   }
 
   const body = await req.json() as ImageRequestBody;

--- a/frontend/src/app/api/ocr/route.ts
+++ b/frontend/src/app/api/ocr/route.ts
@@ -10,13 +10,19 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/api/verifyAuth";
+import { checkRateLimit } from "@/lib/api/rateLimit";
+import { RL_OCR_LIMIT, RL_WINDOW_MS } from "@/lib/constants";
 
 const OLLAMA_URL = process.env.OLLAMA_URL ?? "http://localhost:11434";
 const DEFAULT_OCR_MODEL = process.env.OCR_MODEL ?? "llava";
 
 export async function POST(req: NextRequest) {
-  if (!await verifyToken(req.headers.get("authorization"))) {
+  const authHeader = req.headers.get("authorization");
+  if (!await verifyToken(authHeader)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!checkRateLimit("ocr", authHeader!, RL_OCR_LIMIT, RL_WINDOW_MS)) {
+    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
   }
 
   const body = await req.json() as {

--- a/frontend/src/app/api/websearch/route.ts
+++ b/frontend/src/app/api/websearch/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/api/verifyAuth";
 import { resolveSettingsKey } from "@/lib/api/settingsKeyResolver";
-import { WEBSEARCH_MAX_QUERY_LEN, WEBSEARCH_MAX_RESULTS, WEBSEARCH_TIMEOUT_MS } from "@/lib/constants";
+import { checkRateLimit } from "@/lib/api/rateLimit";
+import { WEBSEARCH_MAX_QUERY_LEN, WEBSEARCH_MAX_RESULTS, WEBSEARCH_TIMEOUT_MS, RL_WEBSEARCH_LIMIT, RL_WINDOW_MS } from "@/lib/constants";
 
 export type SearchResult = {
   title: string;
@@ -13,6 +14,9 @@ export async function GET(req: NextRequest) {
   const authHeader = req.headers.get("authorization") ?? "";
   if (!await verifyToken(authHeader)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!checkRateLimit("websearch", authHeader, RL_WEBSEARCH_LIMIT, RL_WINDOW_MS)) {
+    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
   }
 
   const q = (req.nextUrl.searchParams.get("q") ?? "").slice(0, WEBSEARCH_MAX_QUERY_LEN);

--- a/frontend/src/lib/api/rateLimit.ts
+++ b/frontend/src/lib/api/rateLimit.ts
@@ -1,0 +1,52 @@
+/**
+ * In-process sliding-window rate limiter for Next.js API routes.
+ *
+ * Each (key, namespace) pair gets its own counter that resets after windowMs.
+ * "key" should be a stable per-user identifier — we use the Bearer token since
+ * we don't decode the JWT on the Next.js side.
+ *
+ * The store is bounded at MAX_ENTRIES; expired windows are evicted on overflow.
+ */
+
+type Window = { count: number; reset: number };
+const store = new Map<string, Window>();
+const MAX_ENTRIES = 5_000;
+
+function evict() {
+  if (store.size < MAX_ENTRIES) return;
+  const now = Date.now();
+  for (const [k, v] of store) {
+    if (v.reset < now) store.delete(k);
+    if (store.size < MAX_ENTRIES * 0.75) break;
+  }
+}
+
+/**
+ * Returns true if the request is within the rate limit, false if it should
+ * be rejected (429).
+ *
+ * @param namespace  Route identifier so limits don't bleed across routes.
+ * @param key        Per-user key (auth header / IP / etc.).
+ * @param limit      Max requests allowed per window.
+ * @param windowMs   Window size in milliseconds.
+ */
+export function checkRateLimit(
+  namespace: string,
+  key: string,
+  limit: number,
+  windowMs: number,
+): boolean {
+  evict();
+  const storeKey = `${namespace}:${key}`;
+  const now      = Date.now();
+  const win      = store.get(storeKey);
+
+  if (!win || win.reset < now) {
+    store.set(storeKey, { count: 1, reset: now + windowMs });
+    return true;
+  }
+
+  if (win.count >= limit) return false;
+  win.count++;
+  return true;
+}

--- a/frontend/src/lib/api/verifyAuth.ts
+++ b/frontend/src/lib/api/verifyAuth.ts
@@ -1,18 +1,47 @@
 /**
  * Server-side token verification utility for Next.js API routes.
  * Verifies a Bearer token against the backend /auth/me endpoint.
+ *
+ * Results are cached in process memory for VALID_TTL / INVALID_TTL ms to avoid
+ * a backend round-trip on every proxied request. The cache is bounded at
+ * MAX_ENTRIES; expired entries are evicted when it fills.
  */
 
 const INTERNAL_API = process.env.INTERNAL_API_URL ?? "http://localhost:8000";
 
+const VALID_TTL   = 60_000;  // 60 s — safe; well below typical JWT expiry
+const INVALID_TTL =  5_000;  // 5 s  — limits repeated bad-token hammering
+const MAX_ENTRIES = 1_000;
+
+type CacheEntry = { valid: boolean; exp: number };
+const cache = new Map<string, CacheEntry>();
+
+function evict() {
+  if (cache.size < MAX_ENTRIES) return;
+  const now = Date.now();
+  for (const [k, v] of cache) {
+    if (v.exp < now) cache.delete(k);
+    if (cache.size < MAX_ENTRIES * 0.75) break;
+  }
+}
+
 export async function verifyToken(authHeader: string | null): Promise<boolean> {
   if (!authHeader?.startsWith("Bearer ")) return false;
+
+  const now    = Date.now();
+  const cached = cache.get(authHeader);
+  if (cached && cached.exp > now) return cached.valid;
+
+  evict();
+
   try {
     const res = await fetch(`${INTERNAL_API}/api/v1/auth/me`, {
       headers: { Authorization: authHeader },
       signal: AbortSignal.timeout(3000),
     });
-    return res.ok;
+    const valid = res.ok;
+    cache.set(authHeader, { valid, exp: now + (valid ? VALID_TTL : INVALID_TTL) });
+    return valid;
   } catch {
     return false;
   }

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -39,3 +39,11 @@ export const WEBSEARCH_TIMEOUT_MS    = 10_000;
 // ── chat 보조 호출 타임아웃 ────────────────────────────────────────────────────
 export const RAG_TIMEOUT_MS          = 10_000;  // RAG 검색 타임아웃
 export const OCR_TIMEOUT_MS          = 30_000;  // OCR 타임아웃
+
+// ── API 라우트 레이트 리밋 (Next.js proxy routes) ────────────────────────────
+export const RL_WINDOW_MS            = 60_000;  // 1분 슬라이딩 윈도우
+export const RL_CHAT_LIMIT           = 20;      // LLM 스트리밍: 분당 20회
+export const RL_IMAGE_LIMIT          = 5;       // DALL-E 생성: 분당 5회
+export const RL_IMAGE_EDIT_LIMIT     = 5;       // DALL-E 편집: 분당 5회
+export const RL_OCR_LIMIT            = 10;      // OCR: 분당 10회
+export const RL_WEBSEARCH_LIMIT      = 15;      // 웹 검색: 분당 15회


### PR DESCRIPTION
## Summary
- **Issue #18 — verifyToken performance**: Added an in-process LRU-style cache to `verifyAuth.ts`. Valid tokens are cached for 60 s; invalid tokens for 5 s (limits hammering). Cache is bounded at 1 000 entries with expiry-based eviction. Eliminates a backend round-trip on every proxied chat / image / OCR / websearch request.
- **Issue #17 — rate limiting**: New `rateLimit.ts` utility implements a per-user sliding-window counter. Applied to all 5 proxy routes with conservative limits:

| Route | Limit |
|-------|-------|
| `POST /api/chat` | 20 req/min |
| `POST /api/image` | 5 req/min |
| `POST /api/image/edit` | 5 req/min |
| `POST /api/ocr` | 10 req/min |
| `GET /api/websearch` | 15 req/min |

Rate limit constants live in `lib/constants.ts` alongside other project-wide magic numbers.

## Test plan
- [ ] Normal usage: all routes respond normally within limits
- [ ] Exceeding limit: routes return `429 Rate limit exceeded`
- [ ] Rapid repeated requests with the same token: only one `/auth/me` call fires within the 60 s window (check server logs)
- [ ] `npx tsc --noEmit` and `npx eslint` pass with 0 errors/warnings

Closes #17
Closes #18